### PR TITLE
Add web push notifications

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -216,26 +216,22 @@ async function processOfflineQueue() {
 // Handle push notifications (future feature)
 self.addEventListener('push', (event) => {
   console.log('[SW] Push notification received');
-  
+
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Bau-Structura';
   const options = {
-    body: event.data ? event.data.text() : 'Neue Benachrichtigung',
+    body: data.body || 'Neue Benachrichtigung',
     icon: '/icons/icon-192x192.svg',
     badge: '/icons/icon-192x192.svg',
     tag: 'bau-structura-notification',
     actions: [
-      {
-        action: 'open',
-        title: 'Öffnen'
-      },
-      {
-        action: 'close',
-        title: 'Schließen'
-      }
+      { action: 'open', title: 'Öffnen' },
+      { action: 'close', title: 'Schließen' }
     ]
   };
-  
+
   event.waitUntil(
-    self.registration.showNotification('Bau-Structura', options)
+    self.registration.showNotification(title, options)
   );
 });
 

--- a/client/src/utils/push.ts
+++ b/client/src/utils/push.ts
@@ -1,0 +1,32 @@
+export async function registerPushSubscription() {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+  const reg = await navigator.serviceWorker.ready;
+  const existing = await reg.pushManager.getSubscription();
+  if (existing) return existing;
+  const key = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+  if (!key) {
+    console.warn('VAPID public key missing');
+    return;
+  }
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(key)
+  });
+  await fetch('/api/push/subscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ subscription: sub })
+  });
+  return sub;
+}
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; ++i) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}

--- a/server/pushService.ts
+++ b/server/pushService.ts
@@ -1,0 +1,47 @@
+import { storage } from './storage';
+import type { PushSubscriptionRecord } from '@shared/schema';
+
+let webPush: any = null;
+
+async function getWebPush() {
+  if (!webPush) {
+    try {
+      webPush = await import('web-push');
+      const { VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY } = process.env;
+      if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+        webPush.setVapidDetails(
+          'mailto:support@bau-structura.de',
+          VAPID_PUBLIC_KEY,
+          VAPID_PRIVATE_KEY
+        );
+      } else {
+        console.warn('VAPID keys missing, push notifications disabled');
+      }
+    } catch (err) {
+      console.error('web-push module not available', err);
+      webPush = null;
+    }
+  }
+  return webPush;
+}
+
+export class PushService {
+  async sendToUser(userId: string, payload: Record<string, any>): Promise<void> {
+    const subs = await storage.getPushSubscriptionsByUser(userId);
+    const wp = await getWebPush();
+    if (!wp) return;
+    await Promise.all(
+      subs.map(sub => this.send(sub, payload, wp))
+    );
+  }
+
+  private async send(sub: PushSubscriptionRecord, payload: any, wp: any) {
+    try {
+      await wp.sendNotification(sub.subscription, JSON.stringify(payload));
+    } catch (err) {
+      console.error('Failed to send push', err);
+    }
+  }
+}
+
+export const pushService = new PushService();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -54,6 +54,7 @@ import {
 import { registerTrialAdminRoutes } from './admin-trial-api';
 import { onLicenseActivated, onLicenseCancelled } from './sftpAutoSetup';
 import { registerSftpAdminRoutes } from './routes/sftp-admin';
+import { registerPushRoutes } from './routes/push';
 
 if (!process.env.STRIPE_SECRET_KEY) {
   throw new Error('Missing required Stripe secret: STRIPE_SECRET_KEY');
@@ -96,12 +97,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Register Error Learning API routes
   registerErrorLearningRoutes(app);
-  
+
   // Register Trial Admin API routes
   registerTrialAdminRoutes(app);
-  
+
   // Register SFTP Admin API routes
   registerSftpAdminRoutes(app);
+
+  // Register Push Notification routes
+  registerPushRoutes(app);
 
   // Direkte SFTP-Einrichtung für spezifische Benutzer (Admin-Override)
   app.post("/api/admin/direct-sftp-setup", isAuthenticated, async (req: any, res) => {

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -1,0 +1,38 @@
+import type { Express } from 'express';
+import { isAuthenticated } from '../localAuth';
+import { storage } from '../storage';
+import { pushService } from '../pushService';
+
+export function registerPushRoutes(app: Express) {
+  // register subscription for current user
+  app.post('/api/push/subscribe', isAuthenticated, async (req: any, res) => {
+    try {
+      const { subscription } = req.body;
+      if (!subscription) return res.status(400).json({ message: 'Missing subscription' });
+      const userId = req.user.id;
+      await storage.createPushSubscription({ userId, subscription });
+      res.json({ success: true });
+    } catch (err) {
+      console.error('Subscribe error', err);
+      res.status(500).json({ message: 'Failed to save subscription' });
+    }
+  });
+
+  // send push notification (admin only)
+  app.post('/api/admin/send-push', isAuthenticated, async (req: any, res) => {
+    try {
+      if (req.user.role !== 'admin') {
+        return res.status(403).json({ message: 'Admin required' });
+      }
+      const { userId, title, body } = req.body;
+      if (!userId || !title || !body) {
+        return res.status(400).json({ message: 'Missing fields' });
+      }
+      await pushService.sendToUser(userId, { title, body });
+      res.json({ success: true });
+    } catch (err) {
+      console.error('Send push error', err);
+      res.status(500).json({ message: 'Failed to send push' });
+    }
+  });
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12,6 +12,7 @@ import {
   aiLog,
   customerContacts,
   companyContacts,
+  pushSubscriptions,
   type User,
   type UpsertUser,
   type Project,
@@ -38,6 +39,8 @@ import {
   type InsertCustomerContact,
   type CompanyContact,
   type InsertCompanyContact,
+  type PushSubscriptionRecord,
+  type InsertPushSubscription,
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, desc, and, sql } from "drizzle-orm";
@@ -120,6 +123,11 @@ export interface IStorage {
   createCompanyContact(contact: InsertCompanyContact): Promise<CompanyContact>;
   updateCompanyContact(id: number, contact: Partial<InsertCompanyContact>): Promise<CompanyContact>;
   deleteCompanyContact(id: number): Promise<void>;
+
+  // Push subscription operations
+  createPushSubscription(sub: InsertPushSubscription): Promise<PushSubscriptionRecord>;
+  getPushSubscriptionsByUser(userId: string): Promise<PushSubscriptionRecord[]>;
+  deletePushSubscription(id: number): Promise<void>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -586,6 +594,19 @@ export class DatabaseStorage implements IStorage {
 
   async deleteCompanyContact(id: number): Promise<void> {
     await db.delete(companyContacts).where(eq(companyContacts.id, id));
+  }
+
+  async createPushSubscription(sub: InsertPushSubscription): Promise<PushSubscriptionRecord> {
+    const [created] = await db.insert(pushSubscriptions).values(sub).returning();
+    return created;
+  }
+
+  async getPushSubscriptionsByUser(userId: string): Promise<PushSubscriptionRecord[]> {
+    return await db.select().from(pushSubscriptions).where(eq(pushSubscriptions.userId, userId));
+  }
+
+  async deletePushSubscription(id: number): Promise<void> {
+    await db.delete(pushSubscriptions).where(eq(pushSubscriptions.id, id));
   }
 
   async getUserProjectRoles(userId: string): Promise<any[]> {

--- a/server/trialReminderService.ts
+++ b/server/trialReminderService.ts
@@ -5,6 +5,7 @@
 
 import { storage } from "./storage";
 import { emailService } from "./emailService";
+import { pushService } from "./pushService";
 
 export class TrialReminderService {
   
@@ -84,12 +85,18 @@ export class TrialReminderService {
    */
   private async sendTrialReminderEmail(user: any, daysRemaining: number): Promise<void> {
     const subject = `🚨 Ihr Bau-Structura Testzeitraum läuft in ${daysRemaining} Tagen ab`;
-    
+
     await emailService.sendTrialReminderEmail({
       to: user.email,
       firstName: user.firstName,
       daysRemaining,
       trialEndDate: user.trialEndDate
+    });
+
+    // Matching push notification
+    await pushService.sendToUser(user.id, {
+      title: 'Testzeitraum läuft ab',
+      body: `Ihre Testversion endet in ${daysRemaining} Tagen.`
     });
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -244,6 +244,14 @@ export const loginLog = pgTable("login_log", {
   sessionDuration: integer("session_duration"),
 });
 
+// Web push subscriptions
+export const pushSubscriptions = pgTable("push_subscriptions", {
+  id: serial("id").primaryKey(),
+  userId: varchar("user_id").references(() => users.id).notNull(),
+  subscription: jsonb("subscription").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // AI log table
 export const aiLog = pgTable("ai_log", {
   id: serial("id").primaryKey(),
@@ -318,6 +326,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   supportTickets: many(supportTickets),
   loginLogs: many(loginLog),
   aiLogs: many(aiLog),
+  pushSubscriptions: many(pushSubscriptions),
   projectRoles: many(projectRoles),
 }));
 
@@ -477,6 +486,11 @@ export const insertProjectRoleSchema = createInsertSchema(projectRoles).omit({
   assignedAt: true,
 });
 
+export const insertPushSubscriptionSchema = createInsertSchema(pushSubscriptions).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Types
 export type UpsertUser = typeof users.$inferInsert;
 export type User = typeof users.$inferSelect;
@@ -520,3 +534,6 @@ export type InsertCompanyContact = z.infer<typeof insertCompanyContactSchema>;
 
 export type ProjectRole = typeof projectRoles.$inferSelect;
 export type InsertProjectRole = z.infer<typeof insertProjectRoleSchema>;
+
+export type PushSubscriptionRecord = typeof pushSubscriptions.$inferSelect;
+export type InsertPushSubscription = z.infer<typeof insertPushSubscriptionSchema>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "types": ["node", "vite/client"],
+    "typeRoots": ["./node_modules/@types"],
     "paths": {
       "@/*": ["./client/src/*"],
       "@shared/*": ["./shared/*"]


### PR DESCRIPTION
## Summary
- store push subscriptions in the DB
- expose push subscription and admin send endpoints
- send trial reminder push notifications
- add client helper to register push subscriptions
- show payload content in service worker notifications

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6885d63a55e08330a393c43495449e18